### PR TITLE
gather logged in users via "users" command and only run usermod on those

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,6 +32,17 @@
       setup:
       when: ansible_fqdn is undefined
 
+  # ansible setup module does not gather logged in users
+    - name: command users - store logged in users in regster reg_logged_in_users
+      command: users
+      check_mode: no
+      changed_when: False
+      register: reg_logged_in_users
+
+    - name: set_fact fact_logged_in_users - to make a json list out of reg_logged_in_users
+      set_fact:
+        fact_logged_in_users: "{{ reg_logged_in_users.stdout.split(' ') | default([]) }}"
+
     - name: Create admin group
       group: "name={{admingroup}}"
       register: reg_add_admin_group
@@ -71,7 +82,7 @@
         line: '#includedir /etc/sudoers.d'
       when: admin_sudoers
 
-    - name: Add or remove users from the lists in admin_list_of_user_lists
+    - name: Add or remove not logged in users from the lists in admin_list_of_user_lists
       user:
         name: "{{user.name}}"
         state: "{{user.state | default('present')}}"
@@ -86,33 +97,28 @@
         loop_var: user
         label: "{{ user.name }} {{ user.state }}"
       when:
-        # Ansible user module fails to modify any logged in user when uid is set
-        # Workaround is to run usermod manually for the currently logged in user.
-        - user.uid is not defined
-        - user.name != ansible_ssh_user
+        - user.name not in fact_logged_in_users
 
-    - name: command usermod - ansible_ssh_user primary group and extra groups, workaround for current user failing
+    - name: command usermod - ansible_ssh_user primary group and extra groups, workaround for logged in users
       command: sudo usermod -g {{ user.group }} -G {{ user.groups }} {{ user.name }}
       with_items: "{{ admin_list_of_user_lists | default([]) }}"
       loop_control:
         loop_var: user
         label: "{{ user.name }}"
       when:
-       - user.name == ansible_ssh_user
+       - user.name in fact_logged_in_users
        - user.group is defined
-       - user.uid is defined # We only need this to work round above mentioned bug
 
 # An extra exception if the group key is not defined for the ansible_ssh_user
-    - name: command usermod - ansible_ssh_user extra groups, workaround for current user failing
+    - name: command usermod - ansible_ssh_user extra groups, workaround for logged in users
       command: sudo usermod -G {{ user.groups }} {{ user.name }}
       with_items: "{{ admin_list_of_user_lists | default([]) }}"
       loop_control:
         loop_var: user
         label: "{{ user.name }}"
       when:
-       - user.name == ansible_ssh_user
+       - user.name in fact_logged_in_users
        - user.group is undefined
-
 
     - name: Remove wheel group in sudoers if admin group was added and the sudoers.d file for the admin group was added
       lineinfile:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -85,11 +85,11 @@
       loop_control:
         loop_var: user
         label: "{{ user.name }} {{ user.state }}"
-      when: user.name != ansible_ssh_user
-
-# Ansible user module fails to modify currently logged in user as it is
-# attempting to modify things that did not really change.
-# Workaround is to run usermod manually for the currently logged in user.
+      when:
+        # Ansible user module fails to modify any logged in user when uid is set
+        # Workaround is to run usermod manually for the currently logged in user.
+        - user.uid is not defined
+        - user.name != ansible_ssh_user
 
     - name: command usermod - ansible_ssh_user primary group and extra groups, workaround for current user failing
       command: sudo usermod -g {{ user.group }} -G {{ user.groups }} {{ user.name }}
@@ -100,6 +100,7 @@
       when:
        - user.name == ansible_ssh_user
        - user.group is defined
+       - user.uid is defined # We only need this to work round above mentioned bug
 
 # An extra exception if the group key is not defined for the ansible_ssh_user
     - name: command usermod - ansible_ssh_user extra groups, workaround for current user failing
@@ -108,7 +109,7 @@
       loop_control:
         loop_var: user
         label: "{{ user.name }}"
-      when: 
+      when:
        - user.name == ansible_ssh_user
        - user.group is undefined
 
@@ -127,18 +128,10 @@
         name: "{{user.name}}"
         password: '*'
         state: "{{user.state | default('present')}}"
-        uid: "{{user.uid | default(omit)}}"
-        group: "{{user.group | default(omit)}}"
-        groups: "{{user.groups | default(omit)}}"
-        shell: "{{user.shell | default('/bin/bash')}}"
-        comment: "{{user.comment | default(omit)}}"
-        remove: "{{user.remove | default(omit)}}"
       with_items: "{{ admin_list_of_user_lists | default([])}}"
       when:
         - adminremove_passwords
         - user.state == 'present'
-        # Need to exclude current user or otherwise the task fails when not running as root
-        - user.name != ansible_ssh_user
       loop_control:
         loop_var: user
         label: "{{ user.name }}"


### PR DESCRIPTION
Takes most of the work from PR #30 and to skip logged in users we first gather which users are logged in and then exclude those rather than a few scenarios.