### PR TITLE
Fixing an ansible 2.3 problem

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,9 +28,10 @@ admin_root_keys: []
 
 adminremove_passwords: False
 # If you need to point to a hard coded config file or otherwise mess with the
-# manual ssh which runs at the start of this role to test whether to use the 
+# manual ssh which runs at the start of this role to test whether to use the
 # default user or root.
-ssh_extra_args: "-F ssh.config -o PasswordAuthentication=no"
+# Defaults to ssh_args from ansible.cfg or empty string if that isn't set/found
+ssh_extra_args: "{{ ssh_args | default('') }}"
 # Create groups from a list
 admin_list_of_groups: []
 #

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,8 +6,10 @@
     become: no # We don't want to run as root here
     check_mode: no
     changed_when: false # This never changes anything
-    failed_when: false # The ssh failure doesn't imply a failure of this role
     register: login_as_self
+    failed_when: # The ssh failure doesn't always imply a failure of this role
+      - "{{ login_as_self | failed }}"
+      - "{{ login_as_self.stderr | search('WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!') }}"
 
   - name: Use bootstrap_user to login if current/configured user failed or if fact checking is disabled
     set_fact:
@@ -95,7 +97,7 @@
       loop_control:
         loop_var: user
         label: "{{ user.name }}"
-      when: 
+      when:
        - user.name == ansible_ssh_user
        - user.group is defined
 


### PR DESCRIPTION
We saw an "update_password is always but a password value is missing" error when adding users after upgrading to ansible 2.3. This fixes this and also contains other differences that are still pending from a previous PR.