### PR TITLE
Change conditional for bootstrap_user task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,8 +16,7 @@
       ansible_ssh_user: "{{ bootstrap_user }}"
     check_mode: no
     when:
-      - ansible_fqdn is undefined # Test if fact checking has happened already
-      - login_as_self.rc is defined
+      - login_as_self is defined
       - login_as_self.rc != 0
 
   - name: Use the current/configured username


### PR DESCRIPTION
  * The bootstrap_user task used 3 conditionals to check whether we
    should login as root or current user running the playbooks/s that
    calls this role. The ansible_fqdn var is set to the hypevrisor
    where the machine was deployed and it would always evaluate as
    false

    Changed it to use 2 conditional checks based on the previous task
    in the role that checks if we can login as the person running the
    playbook/s