### PR TITLE
Add decent support for multiple keys per users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,9 @@ adminremove_passwords: false
 
 # multiple ssh keys to a single user
 
-Can be done with this trick:
 <pre>
-newline: "\n"
 
-  - { name: multisshkeyuser, uid: 5004, group: "{{admingroup}}", groups: "agroup,bgroup", state: "present", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY1 {{ newline }} ssh-rsa KEY2 {{ newline }} ssh-rsa KEY3" }
+  - { name: multisshkeyuser, uid: 5004, group: "{{admingroup}}", groups: "agroup,bgroup", state: "present", shell: "{{adminshell}}", pubkeys: [ { pubkey: "ssh-rsa KEY1" }, { pubkey: "ssh-rsa KEY2" }, { pubkey: "ssh-rsa KEY3", key_state: 'absent'  }
 
 </pre>
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,9 @@ admin_sudoers: True
 
 admin_list_of_user_lists: "{{ adminusers |default([]) + moreusers |default([]) }}"
 
+# Whether to remove all other non-specified keys from the authorized_keys file.
+pubkey_exclusive_default: false
+
 admin_root_keys: []
 #admin_root_keys:
 #  - { state: 'present', pubkey: "ssh-rsa KEY admin1@example.com" }

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,11 +28,10 @@ adminremove_passwords: False
 # List of users to remove passwords for
 admin_list_of_user_lists_remove_passwords: "{{ admin_list_of_user_lists }}"
 
-# If you need to point to a hard coded config file or otherwise mess with the
-# manual ssh which runs at the start of this role to test whether to use the
-# default user or root.
-# Defaults to ssh_args from ansible.cfg or empty string if that isn't set/found
-ssh_extra_args: "{{ ssh_args | default('') }}"
+# If you need to add some ssh flags for checking the ssh connection it should
+# be done in this variable, it could be the same as what you have configured
+# in ansible.cfg
+ssh_extra_args: ""
 # Create groups from a list
 admin_list_of_groups: []
 #

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,9 +17,7 @@ admin_sudoers: True
 #moreusers:
 #  - {name: someotheruser1, state: 'present', uid: 6001, shell: "{{adminshell}}" }
 
-admin_list_of_user_lists:
-  - "{{ adminusers | default([]) }}"
-  - "{{ moreusers | default([]) }}"
+admin_list_of_user_lists: "{{ adminusers |default([]) + moreusers |default([]) }}"
 
 admin_root_keys: []
 #admin_root_keys:
@@ -30,9 +28,11 @@ adminremove_passwords: False
 # List of users to remove passwords for
 admin_list_of_user_lists_remove_passwords: "{{ admin_list_of_user_lists }}"
 
-# If you want to use some additional flags when checking ssh connection. You
-# might want to use the same value as `ssh_args` in ansible.cfg
-ssh_extra_args: ""
+# If you need to point to a hard coded config file or otherwise mess with the
+# manual ssh which runs at the start of this role to test whether to use the
+# default user or root.
+# Defaults to ssh_args from ansible.cfg or empty string if that isn't set/found
+ssh_extra_args: "{{ ssh_args | default('') }}"
 # Create groups from a list
 admin_list_of_groups: []
 #

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,11 +30,9 @@ adminremove_passwords: False
 # List of users to remove passwords for
 admin_list_of_user_lists_remove_passwords: "{{ admin_list_of_user_lists }}"
 
-# If you need to point to a hard coded config file or otherwise mess with the
-# manual ssh which runs at the start of this role to test whether to use the
-# default user or root.
-# Defaults to ssh_args from ansible.cfg or empty string if that isn't set/found
-ssh_extra_args: "{{ ssh_args | default('') }}"
+# If you want to use some additional flags when checking ssh connection. You
+# might want to use the same value as `ssh_args` in ansible.cfg
+ssh_extra_args: ""
 # Create groups from a list
 admin_list_of_groups: []
 #

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -175,7 +175,7 @@
         key: '{{ user.pubkey }}'
         key_options: '{{ user.options | default(omit) }}'
         state: "{{ user.key_state | default(omit) }}"
-        exclusive: "{{ user.pubkey_exclusive | default(omit) }}"
+        exclusive: "{{ user.pubkey_exclusive | default(pubkey_exclusive_default) }}"
       when: user.state == 'present' and user.pubkey is defined
       with_items: "{{ admin_list_of_user_lists | default([]) }}"
       loop_control:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,7 +72,7 @@
         name: python3-libselinux
         state: present
       when: ansible_os_family == "RedHat" and ansible_distribution_major_version >= "8"
-      
+
     - name: Create sudoers file for admin group
       copy:
         dest: "/etc/sudoers.d/{{ admingroup }}"
@@ -178,17 +178,17 @@
       loop_control:
         loop_var: user
         label: "{{ user.name }}"
-
     - name: Add or remove ssh keys and use key_options if user have multiple keys
       authorized_key:
         user: "{{ item[0].name }}"
-        key: '{{ item[1].pubkey }}'
-        key_options: '{{ itme[1].options | default(omit) }}'
+        key: "{{ item[1].pubkey }}"
+        key_options: "{{ item[1].options | default(omit) }}"
         state: "{{ item[1].key_state | default(omit) }}"
-      when: user.state == 'present' and user.pubkeys is defined
+      when: item[0].state == 'present'
       with_subelements:
-         - "{{ admin_list_of_user_lists | default([])}}"
-         - pubkeys: {'skip_missing': True}
+         - "{{ admin_list_of_user_lists }}"
+         - pubkeys
+         - skip_missing: true
 
     - name: Add to or remove ssh keys from root user
       authorized_key:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,7 @@
 ---
 # This role no longer needs to be run with gather_facts disabled (as long as
 # you have a working user account
-  - name: Test login as current/configured user if fact checking is disabled.
-    # There is no builtin timeout function in ansible and all OS (OSX) does not
-    # come with timeoout built in. Maybe worth considering async or wait for
-    # ansible 2.10.
+  - name: Test login as current/configured user if fact checking is disabled. Timeout 10s.
     command: ssh {{ ssh_extra_args }} {{ inventory_hostname }} whoami
     become: no # We don't want to run as root here
     check_mode: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,10 @@
 ---
 # This role no longer needs to be run with gather_facts disabled (as long as
 # you have a working user account
-  - name: Test login as current/configured user if fact checking is disabled. Timeout 10s.
+  - name: Test login as current/configured user if fact checking is disabled.
+    # There is no builtin timeout function in ansible and all OS (OSX) does not
+    # come with timeoout built in. Maybe worth considering async or wait for
+    # ansible 2.10.
     command: ssh {{ ssh_extra_args }} {{ inventory_hostname }} whoami
     become: no # We don't want to run as root here
     check_mode: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -172,11 +172,23 @@
         key: '{{ user.pubkey }}'
         key_options: '{{ user.options | default(omit) }}'
         state: "{{ user.key_state | default(omit) }}"
+        exclusive: "{{ user.pubkey_exclusive | default(omit) }}"
       when: user.state == 'present' and user.pubkey is defined
       with_items: "{{ admin_list_of_user_lists | default([]) }}"
       loop_control:
         loop_var: user
         label: "{{ user.name }}"
+
+    - name: Add or remove ssh keys and use key_options if user have multiple keys
+      authorized_key:
+        user: "{{ item[0].name }}"
+        key: '{{ item[1].pubkey }}'
+        key_options: '{{ itme[1].options | default(omit) }}'
+        state: "{{ item[1].key_state | default(omit) }}"
+      when: user.state == 'present' and user.pubkeys is defined
+      with_subelements:
+         - "{{ admin_list_of_user_lists | default([])}}"
+         - pubkeys: {'skip_missing': True}
 
     - name: Add to or remove ssh keys from root user
       authorized_key:

--- a/tests/test_idempotency.yml
+++ b/tests/test_idempotency.yml
@@ -18,7 +18,7 @@
        - {name: admin10, state: 'present', uid: 5010, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin10@example.com", key_state: "absent" }
        - {name: admin11, state: 'present', uid: 5011, group: "{{admingroup}}", shell: "{{adminshell}}", home: "/var/lib/admin11", create_home: "yes" }
        - {name: admin12, state: 'present', uid: 5012, password: "$6$1lg6WhuGmrG1QE5X$O9xMkmnsULiqDeZ3DdSKQrHcGeCW4U7FKLhWQIRQGKsG5sslmWUcgQLHz.T/lNqJhVmk8m9OJ2Iv.ogJn7x/" }
-       - {name: admin13, state: 'present', uid: 5013, group: "{{admingroup}}", shell: "{{adminshell}}", pubkeys: [ { pubkey: "ssh-rsa KEY admin13@exampleA.com" },{ pubkey: "ssh-rsa KEY admin13@exampleB.com"}, { pubkey: "ssh-rsa KEY admin13@exampleC.com", key_state: absent }] }
+       - {name: admin13, state: 'present', uid: 5013, group: "{{admingroup}}", shell: "{{adminshell}}", pubkeys: [ { pubkey: "ssh-rsa KEY1 admin13@exampleA.com" },{ pubkey: "ssh-rsa KEY2 admin13@exampleB.com"}, { pubkey: "ssh-rsa KEY3 admin13@exampleC.com", key_state: absent }] }
      - moreusers:
        - {name: user1, state: 'present', uid: 6001, shell: "{{adminshell}}" }
        - {name: user2, state: 'present', uid: 6002 }

--- a/tests/test_idempotency.yml
+++ b/tests/test_idempotency.yml
@@ -18,6 +18,7 @@
        - {name: admin10, state: 'present', uid: 5010, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin10@example.com", key_state: "absent" }
        - {name: admin11, state: 'present', uid: 5011, group: "{{admingroup}}", shell: "{{adminshell}}", home: "/var/lib/admin11", create_home: "yes" }
        - {name: admin12, state: 'present', uid: 5012, password: "$6$1lg6WhuGmrG1QE5X$O9xMkmnsULiqDeZ3DdSKQrHcGeCW4U7FKLhWQIRQGKsG5sslmWUcgQLHz.T/lNqJhVmk8m9OJ2Iv.ogJn7x/" }
+       - {name: admin13, state: 'present', uid: 5001, group: "{{admingroup}}", shell: "{{adminshell}}", pubkeys: [ { pubkey: "ssh-rsa KEY admin13@exampleA.com" },{ pubkey: "ssh-rsa KEY admin13@exampleB.com"}, { pubkey: "ssh-rsa KEY admin13@exampleC.com", key_state: absent }] }
      - moreusers:
        - {name: user1, state: 'present', uid: 6001, shell: "{{adminshell}}" }
        - {name: user2, state: 'present', uid: 6002 }
@@ -33,10 +34,7 @@
        - {name: training1, state: 'present', uid: 7001, shell: "{{adminshell}}" }
        - {name: training2, state: 'present', uid: 7002 }
        - {name: training3, state: 'absent', uid: 7003 }
-     - admin_list_of_user_lists:
-       - "{{ adminusers | default([]) }}"
-       - "{{ moreusers | default([]) }}"
-       - "{{ anotheruserlisthere | default([]) }}"
+     - admin_list_of_user_lists: "{{ adminusers | default([]) + moreusers | default([]) + anotheruserlisthere | default([]) }}"
  
      - admin_root_keys:
        - { state: 'present', pubkey: "ssh-rsa KEY admin1@example.com" }

--- a/tests/test_idempotency.yml
+++ b/tests/test_idempotency.yml
@@ -18,7 +18,7 @@
        - {name: admin10, state: 'present', uid: 5010, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin10@example.com", key_state: "absent" }
        - {name: admin11, state: 'present', uid: 5011, group: "{{admingroup}}", shell: "{{adminshell}}", home: "/var/lib/admin11", create_home: "yes" }
        - {name: admin12, state: 'present', uid: 5012, password: "$6$1lg6WhuGmrG1QE5X$O9xMkmnsULiqDeZ3DdSKQrHcGeCW4U7FKLhWQIRQGKsG5sslmWUcgQLHz.T/lNqJhVmk8m9OJ2Iv.ogJn7x/" }
-       - {name: admin13, state: 'present', uid: 5001, group: "{{admingroup}}", shell: "{{adminshell}}", pubkeys: [ { pubkey: "ssh-rsa KEY admin13@exampleA.com" },{ pubkey: "ssh-rsa KEY admin13@exampleB.com"}, { pubkey: "ssh-rsa KEY admin13@exampleC.com", key_state: absent }] }
+       - {name: admin13, state: 'present', uid: 5013, group: "{{admingroup}}", shell: "{{adminshell}}", pubkeys: [ { pubkey: "ssh-rsa KEY admin13@exampleA.com" },{ pubkey: "ssh-rsa KEY admin13@exampleB.com"}, { pubkey: "ssh-rsa KEY admin13@exampleC.com", key_state: absent }] }
      - moreusers:
        - {name: user1, state: 'present', uid: 6001, shell: "{{adminshell}}" }
        - {name: user2, state: 'present', uid: 6002 }


### PR DESCRIPTION
- The previous `newline` hack does not work once one wants to remove keys. 
  By using `pubkeys` it is now possible to maintain users with multiple keys.
- Adding support for `exclusive` to force users to only have one public key.
- Change `admin_list_of_user_lists` to not be a list of lists. This should make
  it possible to clean up some of the loops in the future and it makes it possible 
  to use `with_subelements`.
- Update README to recommend the new method of adding multiple keys.
- Remove the timeout from the ssh check since it will fail for users that does
  not have timeout installed on their laptop. Ansible 2.10 should add timeout
  to Ansible tasks as an option.
- Remove `ssh_args` as a default option since it does not get the value from
  ansible.cfg and it is confusing. This could potentially break for users the
  user experience if user have configured the variable but it is probably 
  better to use another variable name to limit confusion.
CSCWOOD-150