### PR TITLE
CentOS-8 does not require python3-libselinux

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,12 +67,6 @@
         state: present
       when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
 
-    - name: Install Python SE Linux support for Centos 8
-      package:
-        name: python3-libselinux
-        state: present
-      when: ansible_os_family == "RedHat" and ansible_distribution_major_version >= "8"
-      
     - name: Create sudoers file for admin group
       copy:
         dest: "/etc/sudoers.d/{{ admingroup }}"


### PR DESCRIPTION
It is possible to create users without python3-libselinux even if
SELinux is enabled.

Dnf might have issues otherwise if the dnf proxy is not configured
before this role is run.
CSCWOOD-63