### PR TITLE
Remove libselinux-python installation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,12 +61,6 @@
         loop_var: group
         label: "{{ group.name }}"
 
-    - name: Install Python SE Linux support (needed on CentOS7 with Enforcing)
-      package:
-        name: libselinux-python
-        state: present
-      when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
-
     - name: Create sudoers file for admin group
       copy:
         dest: "/etc/sudoers.d/{{ admingroup }}"


### PR DESCRIPTION
- In #54 ansible_os_family was added which made this role to no longer be
factless. This is a huge problem since it destroy the whole point of the first
task to check with which user one should log in with on a freshly installed
system.

- It seems that libselinux-python is not longer needed in my test nor is it
stated in the ansible documentation

CSCWOOD-180