### PR TITLE
Fix pip version

### DIFF
--- a/tests/ansible-min-version-centos7/Dockerfile
+++ b/tests/ansible-min-version-centos7/Dockerfile
@@ -12,6 +12,7 @@ RUN yum clean all && \
     yum -y remove $(rpm -qa "*-devel") && \
     yum -y groupremove "Development tools" && \
     yum -y autoremove && \
+    pip install --upgrade "pip < 21.0" && \
     yum -y install bzip2 file findutils gem git gzip hg procps-ng svn sudo tar tree which unzip xz zip
 
 RUN mkdir /etc/ansible/

--- a/tests/devel-centos7/Dockerfile
+++ b/tests/devel-centos7/Dockerfile
@@ -14,6 +14,7 @@ RUN yum clean all && \
     yum -y install acl sudo && \
     sed -i -e 's/^Defaults.*requiretty/Defaults    !requiretty/' -e 's/^%wheel.*ALL$/%wheel    ALL=(ALL)    NOPASSWD: ALL/' /etc/sudoers && \
     yum -y install PyYAML python-jinja2 python-httplib2 python-keyczar python-paramiko python-setuptools git python-pip && \
+    pip install --upgrade "pip < 21.0" && \
     pip install pysphere passlib dnspython && \
     sh -c 'yum -y remove libffi-devel || yum -y --setopt=tsflags=noscripts remove libffi-devel' && \
     yum -y remove $(rpm -qa "*-devel") && \

--- a/tests/pip-ubuntu/Dockerfile
+++ b/tests/pip-ubuntu/Dockerfile
@@ -36,6 +36,7 @@ RUN \
   apt-get install -y byobu curl git htop man unzip vim wget python-pip tree && \
   apt-get install -y libyaml-dev python-dev python-jinja2 python-httplib2 python-keyczar python-paramiko python-setuptools python3-setuptools && \
   apt-get install -y libffi-dev libssl-dev openssh-client && \
+  pip install --upgrade "pip < 21.0" && \
   pip install pyrax pysphere boto passlib dnspython
 
 RUN mkdir /etc/ansible/

--- a/tests/stable-centos7/Dockerfile
+++ b/tests/stable-centos7/Dockerfile
@@ -12,7 +12,8 @@ RUN yum clean all && \
     yum -y remove $(rpm -qa "*-devel") && \
     yum -y groupremove "Development tools" && \
     yum -y autoremove && \
-    yum -y install bzip2 file findutils gem git gzip hg procps-ng svn sudo tar tree which unzip xz zip
+    yum -y install bzip2 file findutils gem git gzip hg procps-ng svn sudo tar tree which unzip xz zip && \
+    pip install --upgrade "pip < 21.0"
 
 RUN mkdir /etc/ansible/
 RUN echo -e '[local]\nlocalhost' > /etc/ansible/hosts


### PR DESCRIPTION
pip versions later than this break the tests. Fixing this resolves automated tests.

At some point we should recreate all these tests to be python3 only.