### PR TITLE
Remove pyrax from testing Dockerfile for ubuntu 16.04

### DIFF
--- a/tests/pip-ubuntu/Dockerfile
+++ b/tests/pip-ubuntu/Dockerfile
@@ -37,6 +37,7 @@ RUN \
   apt-get install -y libyaml-dev python-dev python-jinja2 python-httplib2 python-keyczar python-paramiko python-setuptools python3-setuptools && \
   apt-get install -y libffi-dev libssl-dev openssh-client && \
   pip install --upgrade "pip < 21.0" && \
+  pip install pbr && \
   pip install pyrax pysphere boto passlib dnspython
 
 RUN mkdir /etc/ansible/

--- a/tests/pip-ubuntu/Dockerfile
+++ b/tests/pip-ubuntu/Dockerfile
@@ -37,8 +37,7 @@ RUN \
   apt-get install -y libyaml-dev python-dev python-jinja2 python-httplib2 python-keyczar python-paramiko python-setuptools python3-setuptools && \
   apt-get install -y libffi-dev libssl-dev openssh-client && \
   pip install --upgrade "pip < 21.0" && \
-  pip install pbr && \
-  pip install pyrax pysphere boto passlib dnspython
+  pip install pysphere boto passlib dnspython
 
 RUN mkdir /etc/ansible/
 RUN echo -e '[local]\nlocalhost' > /etc/ansible/hosts


### PR DESCRIPTION
In a python2.7 environment, pyrax has the following dependency:
```
pbr<2.0,>=1.6
```
At the same time, other dependencies of pyrax itself are for example:
```
keystoneauth1>=3.4.0
```
which in turn has the following dependency:
```
keystoneauth1 4.0.1 requires pbr!=2.1.0,>=2.0.0
```
so pyrax cannot be installed as is anymore apparently, thus leading the corresponding Travis check to fail.

The line in the dockerfile installs several libraries for interacting with cloud environments, e.g., openstack, AWS, but to the best of my knowledge these are not really needed in the testing. Sticking to the principle of minimal changes, I am proposing to remove the pyrax library only from the list of packages to be installed.