### PR TITLE
Test the usermod a bit more and use type_debug jinja filter!

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -117,6 +117,7 @@
        - user.name in admin_logged_in_users
        - user.group is defined
        - user.groups is defined
+       - user.groups|type_debug == 'AnsibleUnsafeText'
        - user.uid is defined # We only need this usermod command to set group and groups for any logged in users
 
     # An extra exception if the group key is not defined for the logged in user
@@ -130,6 +131,7 @@
        - user.name in admin_logged_in_users
        - user.group is undefined
        - user.groups is defined
+       - user.groups|type_debug == 'AnsibleUnsafeText'
 
     - name: Remove wheel group in sudoers if admin group was added and the sudoers.d file for the admin group was added
       lineinfile:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -117,7 +117,7 @@
        - user.name in admin_logged_in_users
        - user.group is defined
        - user.groups is defined
-       - user.groups == "AnsibleUnsafeText"
+       - "{{ user.groups | type_debug }} == 'AnsibleUnsafeText'"
        - user.uid is defined # We only need this usermod command to set group and groups for any logged in users
 
     # An extra exception if the group key is not defined for the logged in user
@@ -131,7 +131,7 @@
        - user.name in admin_logged_in_users
        - user.group is undefined
        - user.groups is defined
-       - user.groups == "AnsibleUnsafeText"
+       - "{{ user.groups | type_debug }} == 'AnsibleUnsafeText'"
 
     - name: Remove wheel group in sudoers if admin group was added and the sudoers.d file for the admin group was added
       lineinfile:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -117,7 +117,7 @@
        - user.name in admin_logged_in_users
        - user.group is defined
        - user.groups is defined
-       - "{{ user.groups | type_debug }} == 'AnsibleUnsafeText'"
+       - user.groups|type_debug == 'AnsibleUnsafeText'
        - user.uid is defined # We only need this usermod command to set group and groups for any logged in users
 
     # An extra exception if the group key is not defined for the logged in user
@@ -131,7 +131,7 @@
        - user.name in admin_logged_in_users
        - user.group is undefined
        - user.groups is defined
-       - "{{ user.groups | type_debug }} == 'AnsibleUnsafeText'"
+       - user.groups|type_debug == 'AnsibleUnsafeText'
 
     - name: Remove wheel group in sudoers if admin group was added and the sudoers.d file for the admin group was added
       lineinfile:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -117,7 +117,6 @@
        - user.name in admin_logged_in_users
        - user.group is defined
        - user.groups is defined
-       - user.groups|type_debug == 'AnsibleUnsafeText'
        - user.uid is defined # We only need this usermod command to set group and groups for any logged in users
 
     # An extra exception if the group key is not defined for the logged in user
@@ -131,7 +130,6 @@
        - user.name in admin_logged_in_users
        - user.group is undefined
        - user.groups is defined
-       - user.groups|type_debug == 'AnsibleUnsafeText'
 
     - name: Remove wheel group in sudoers if admin group was added and the sudoers.d file for the admin group was added
       lineinfile:

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -9,7 +9,7 @@
        - {name: user4, state: 'present', uid: 6004 }
        - {name: user9, state: 'present', uid: 6009, password: "$6$1lg6WhuGmrG1QE5X$O9xMkmnsULiqDeZ3DdSKQrHcGeCW4U7FKLhWQIRQGKsG5sslmWUcgQLHz.T/lNqJhVmk8m9OJ2Iv.ogJn7xNr/" }
        - {name: user10, state: 'present', uid: 6010, group: "{{admingroup}}" }
-       - {name: user11, state: 'present', uid: 6011, group: "{{admingroup}}", generate_ssh_key: "yes" }
+       - {name: user11, state: 'present', uid: 6011, group: "{{admingroup}}", generate_ssh_key: "yes", groups: ["bgroup"]  }
    roles:
      - ansible-role-users
    post_tasks:
@@ -20,6 +20,10 @@
      - name: launch a screen as user10 and then later we try to change a group for this user
        command: screen -S changemyuid -d -m sleep 600
        become_user: user10
+       become: True
+     - name: launch a screen as user11 and then later we try to add a group from a list of groups
+       command: screen -S changemygroups11 -d -m sleep 600
+       become_user: user11
        become: True
 
  - import_playbook: test_idempotency.yml

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -3,6 +3,9 @@
    hosts: localhost
    remote_user: root
    vars:
+     - admin_list_of_groups:
+       - { name: agroup, gid: 27001 }
+       - { name: bgroup, gid: 27002 }
      - adminusers:
        - {name: admin6, state: 'present', uid: 5006, group: "{{admingroup}}", shell: "{{adminshell}}" }
      - moreusers:

--- a/tests/test_idempotency.yml
+++ b/tests/test_idempotency.yml
@@ -10,7 +10,7 @@
        - {name: admin2, state: 'present', uid: 5002, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin2@example.com", groups: "agroup" }
        - {name: admin3, state: 'present', uid: 5003, groups: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin3@example.com" }
        - {name: admin4, state: 'present', uid: 5004, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin4@example.com", groups: "bgroup" }
-       - {name: admin5, state: 'present', uid: 5005, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin5@example.com", groups: "agroup,bgroup" }
+       - {name: admin5, state: 'present', uid: 5005, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin5@example.com", groups: "agroup,bgroup", comment: "Not logged in, groups is two groups and a csv string" }
        - {name: admin6, state: 'absent', uid: 5006, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin6@example.com", groups: "agroup,bgroup" }
        - {name: admin7, state: 'absent', uid: 5007, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin7@example.com", groups: "agroup,bgroup", comment: "commentB" }
        - {name: admin8, state: 'present', uid: 5008, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin8@example.com", groups: "bgroup", comment: "commentB", remove: "no" }
@@ -29,8 +29,9 @@
        - {name: user7, state: 'absent', uid: 6007, pubkey: "ssh-rsa KEY6 user6@example.com", options: 'command="/usr/local/bin/rrsync /allow/rrsync/here/directory",no-agent-forwarding,no-port-forwarding,no-pty,no-user-rc,no-X11-forwarding' }
        - {name: user8, state: 'absent', uid: 6008, comment: "comment1", remove: "yes" }
        - {name: user9, state: 'present', uid: 6009 }
-       - {name: user10, state: 'present', uid: 6010, group: "{{admingroup}}", groups: "agroup" }
-       - {name: user11, state: 'present', uid: 6011, group: "{{admingroup}}", groups: ["agroup","bgroup"] }
+       - {name: user10, state: 'present', uid: 6010, group: "{{admingroup}}", groups: "agroup", comment: "Logged in, groups is one group and a string" }
+       - {name: user11, state: 'present', uid: 6011, group: "{{admingroup}}", groups: ["agroup","bgroup"], comment: "Logged in, groups is a list" }
+       - {name: user12, state: 'present', uid: 6012, group: "{{admingroup}}", groups: ["agroup","bgroup"], comment: "Not logged in, groups is a list" }
      - anotheruserlisthere:
        - {name: training1, state: 'present', uid: 7001, shell: "{{adminshell}}" }
        - {name: training2, state: 'present', uid: 7002 }


### PR DESCRIPTION
Today I learnt about the type_debug jinja filter :) Googling for AnsibleUnsafeText found me a [blog post](https://www.middlewareinventory.com/blog/ansible-facts-list-how-to-use-ansible-facts/)

Should this caveat be documented?

Instead, one could add (two?) more usermod tasks and convert the [ group1, group2 ] into a string. But leaving that as an exercise for the reviewer if they're up for it. 

**Test 1)**

If I remember things correctly:
- Usermod -G wants a list of groups in `group1,group2`
- ansible user module accepts the above and also in format `[ group1, group2 ]`
  - would be cool if this role supported both

The usermod task `command usermod - primary group and extra groups, workaround for logged in users` now only runs against user10, not against user11 which has the list of users in an array/list.

End result of the test has:

```
agroup:x:27001:admin2,admin5,user10
bgroup:x:27002:user11,admin4,admin5,admin8
```

So user11 did not get the agroup, because it's logged in.
Admin5 got both agroup and bgroup, because it's not logged in and the groups are in unsafetest

**Test 2)** 

Remove the conditional with type_debug filter and see if the test fails

**Test 3)** 

It did fail.

Revert test 2 ddafb1b1bbe4a3ecb605113899631b628b3d9eaf

User 11 still does not get both groups. This is expected.

**Test 4)** current last commit by me  9a9dc4cffd695569953465a8bdb400ed9acf8c20

Add user12 to make sure a user that is not logged in gets both groups.

Resulting getent groups has user12 in both groups.

```
agroup:x:27001:admin2,admin5,user12,user10
bgroup:x:27002:user11,admin4,admin5,admin8,user12
```