### PR TITLE
prevent travis check failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 sudo: required
-dist: trusty
+dist: xenial
 group: edge
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 sudo: required
-dist: xenial
+dist: trusty
 group: edge
 
 services:

--- a/tests/stable-centos7/Dockerfile
+++ b/tests/stable-centos7/Dockerfile
@@ -17,6 +17,6 @@ RUN yum clean all && \
 
 RUN mkdir /etc/ansible/
 RUN echo -e '[local]\nlocalhost' > /etc/ansible/hosts
-RUN pip install ansible
+RUN pip install "ansible<=2.9.1"
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
Travis check is failing.
Forcing pip to install a particular version of ansible(2.9.1).

Moreover: trusty is long EOL, I personally like to use xenial as xenial
still has ESM in .travis.yml file.

fix-travis