### PR TITLE
Fix failing centos7 travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,8 @@ before_script:
   # Launch the container
   - docker run --privileged -d -ti -e "container=docker"  -v `pwd`:/$ROLETOTEST -v /sys/fs/cgroup:/sys/fs/cgroup  ${REPO}:${IMAGE_BUILD_PLATFORM}  /usr/sbin/init
   - DOCKER_CONTAINER_ID=$(docker ps | grep ${IMAGE_BUILD_PLATFORM} | awk '{print $1}')
-  # If ansible-min-version install it with pip
-  - if [ "$IMAGE_BUILD_PLATFORM" == "ansible-min-version-centos7" ]; then docker exec -ti $DOCKER_CONTAINER_ID /bin/sh -c "/usr/bin/pip install ansible==$MIN_ANSIBLE_VERSION"; fi
+  # If ansible-min-version install it with yum
+  - if [ "$IMAGE_BUILD_PLATFORM" == "ansible-min-version-centos7" ]; then docker exec -ti $DOCKER_CONTAINER_ID /bin/sh -c "/usr/bin/yum -y install ansible-$MIN_ANSIBLE_VERSION"; fi
   - docker logs $DOCKER_CONTAINER_ID
 script:
   # Testing of this ansible-role:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
   # - Apache
   # - CC-BY
   license: MIT
-  min_ansible_version: 2.8.17
+  min_ansible_version: 2.9.27
   #
   # Below are all platforms currently available. Just uncomment
   # the ones that apply to your role. If you don't see your

--- a/tests/ansible-min-version-centos7/Dockerfile
+++ b/tests/ansible-min-version-centos7/Dockerfile
@@ -1,7 +1,9 @@
 # Latest version of centos
 FROM centos:centos7
 MAINTAINER James Cuzella <james.cuzella@lyraphase.com>
-RUN yum clean all && \
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
+    yum clean all && \
     yum -y install epel-release && \
     yum -y groupinstall "Development tools" && \
     yum -y install python-devel MySQL-python sshpass && \

--- a/tests/devel-centos7/Dockerfile
+++ b/tests/devel-centos7/Dockerfile
@@ -1,7 +1,9 @@
 # Latest version of centos
 FROM centos:centos7
 MAINTAINER James Cuzella <james.cuzella@lyraphase.com>
-RUN yum clean all && \
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
+    yum clean all && \
     yum -y install epel-release && \
     yum makecache all && \
     yum -y groups mark convert && \

--- a/tests/epel-centos7/Dockerfile
+++ b/tests/epel-centos7/Dockerfile
@@ -1,7 +1,9 @@
 # Latest version of centos
 FROM centos:centos7
 MAINTAINER James Cuzella <james.cuzella@lyraphase.com>
-RUN yum clean all && \
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
+    yum clean all && \
     yum -y install epel-release && \
     yum -y install python-devel MySQL-python sshpass && \
     yum -y install acl sudo && \

--- a/tests/stable-centos7/Dockerfile
+++ b/tests/stable-centos7/Dockerfile
@@ -1,7 +1,9 @@
 # Latest version of centos
 FROM centos:centos7
 MAINTAINER James Cuzella <james.cuzella@lyraphase.com>
-RUN yum clean all && \
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
+    yum clean all && \
     yum -y install epel-release && \
     yum -y groupinstall "Development tools" && \
     yum -y install python-devel MySQL-python sshpass && \

--- a/tests/stable-centos7/Dockerfile
+++ b/tests/stable-centos7/Dockerfile
@@ -19,6 +19,6 @@ RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
 
 RUN mkdir /etc/ansible/
 RUN echo -e '[local]\nlocalhost' > /etc/ansible/hosts
-RUN pip install "ansible<=2.9.1"
+RUN yum -y install ansible-2.9.27
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
In travis tests using Centos 7, the repos were broken to due to Centos 7 EOL. The new repo urls were set to point to vault.centos.

 min_ansible_version was increased to 2.9.27. Installation of the older Ansible version using pip was failing, and upgrade to Ansible 2.9 was the smallest step that could be taken.

Installation of ansible was fixed by replacing pip installtion with yum in ansible-min-version-centos7 and stable-centos7 dockerfiles.
 