### PR TITLE
Allow both @includedir and #includedir in sudoers.conf

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,24 +68,10 @@
       loop_control:
         loop_var: group
         label: "{{ group.name }}"
-
-    - name: Create sudoers file for admin group
-      copy:
-        dest: "/etc/sudoers.d/{{ admingroup }}"
-        owner: "root"
-        group: "root"
-        mode: 0440
-        content: '%{{ admingroup }} ALL=(ALL) NOPASSWD:ALL'
-        validate: 'visudo -cf %s'
-      register: reg_add_sudoers_file_admins
-      when: admin_sudoers|bool
-
-    - name: Ensure /etc/sudoers.d is scanned by sudo
-      lineinfile:
-        dest: '/etc/sudoers'
-        regexp: '#includedir\s+/etc/sudoers.d'
-        line: '#includedir /etc/sudoers.d'
-      when: admin_sudoers|bool
+    
+    - name: Modify sudoers file for admin group
+      import_tasks: modify_sudoers.yml
+      when: admin_sudoers|bool      
 
     - name: Add or remove users from the lists in admin_list_of_user_lists
       user:

--- a/tasks/modify_sudoers.yml
+++ b/tasks/modify_sudoers.yml
@@ -1,0 +1,35 @@
+---
+
+- name: Create sudoers file for admin group
+  copy:
+    dest: "/etc/sudoers.d/{{ admingroup }}"
+    owner: "root"
+    group: "root"
+    mode: 0440
+    content: '%{{ admingroup }} ALL=(ALL) NOPASSWD:ALL'
+    validate: 'visudo -cf %s'
+  register: reg_add_sudoers_file_admins
+
+- name: Read /etc/sudoers content
+  ansible.builtin.slurp:
+    path: /etc/sudoers
+  register: sudoers_content
+
+- name: Decode sudoers content
+  ansible.builtin.set_fact:
+    sudoers_text: "{{ sudoers_content['content'] | b64decode }}"
+
+- name: Check if includedir line exists
+  ansible.builtin.set_fact:
+    include_exists: >-
+      {{ sudoers_text.find('@includedir /etc/sudoers.d') != -1 or
+        sudoers_text.find('#includedir /etc/sudoers.d') != -1 }}
+
+- name: "Add #includedir /etc/sudoers.d only if not present"
+  ansible.builtin.lineinfile:
+    path: /etc/sudoers
+    line: '#includedir /etc/sudoers.d'
+    insertafter: '^# See sudoers\\(5\\) for more information on \"@include\" directives:'
+    validate: '/usr/sbin/visudo -cf %s'
+  when:
+    - not include_exists


### PR DESCRIPTION
This pull request addresses issue #76, where line

` #includedir /etc/sudoers.d` is added to to /etc/sudoers file 
even when newer syntax `@includedir /etc/sudoers.d` is  present in the file.

Now we are adding  #includedir /etc/sudoers.d`only if neither of options is available.