### PR TITLE
Check if ansible async timed out only if login_as_self.msg is defined

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
     fail:
       msg: The ssh connection attempt is hanging, please check e.g. your internet connection and that you don't have any stale ssh file socket
     when:
-      - login_as_self is defined
+      - login_as_self.msg is defined
       - login_as_self.msg is search('Timeout exceeded')
 
   - name: Use bootstrap_user to login if current/configured user failed or if fact checking is disabled


### PR DESCRIPTION
Fixes the issue #80.